### PR TITLE
Added I/O token check and method to check propper words

### DIFF
--- a/lexer.h
+++ b/lexer.h
@@ -4,64 +4,64 @@ std::string sourceCode{};
 std::string currentToken{};
 
 enum tokens {
-    // Keywords
-    token_INPUT,
-    token_OUTPUT,
-    token_IF,
-    token_THEN,
-    token_ELSE_IF,
-    token_ELSE,
-    token_WHILE,
-    token_EXECUTE,
-    token_DO_WHILE,
-    token_FOR,
+	// Keywords
+	token_INPUT,
+	token_OUTPUT,
+	token_IF,
+	token_THEN,
+	token_ELSE_IF,
+	token_ELSE,
+	token_WHILE,
+	token_EXECUTE,
+	token_DO_WHILE,
+	token_FOR,
 
-    // Literals [FACUT]
-    token_FLOAT,
-    token_STRING,
-    token_BOOL,
+	// Literals [FACUT]
+	token_FLOAT,
+	token_STRING,
+	token_BOOL,
 
-    // Data types when reading
-    // spre exemplu citeste x (numar natural, nenul)
-    // citeste x,y,z (numere reale)
-    token_ASSIGN_NATURAL,
-    token_ASSIGN_nonzeroNATURAL,
-    token_ASSIGN_INT,
-    token_ASSIGN_nonzeroINT,
-    token_ASSIGN_FLOAT,
-    token_ASSIGN_nonzeroFLOAT,
-    token_ASSIGN_STRING,
-    token_ASSIGN_BOOL,
+	// Data types when reading
+	// spre exemplu citeste x (numar natural, nenul)
+	// citeste x,y,z (numere reale)
+	token_ASSIGN_NATURAL,
+	token_ASSIGN_nonzeroNATURAL,
+	token_ASSIGN_INT,
+	token_ASSIGN_nonzeroINT,
+	token_ASSIGN_FLOAT,
+	token_ASSIGN_nonzeroFLOAT,
+	token_ASSIGN_STRING,
+	token_ASSIGN_BOOL,
 
-    // Operands
-    token_ASSIGN,
-    token_PLUS,
-    token_MINUS,
-    token_ASTERISK,
-    token_DIVISION,
-    token_MODULO,
-    token_POWER,
+	// Operands
+	token_ASSIGN,
+	token_PLUS,
+	token_MINUS,
+	token_ASTERISK,
+	token_DIVISION,
+	token_MODULO,
+	token_POWER,
 
-    // Logic
-    token_GREATER,
-    token_GREATER_EQUAL,
-    token_SMALLER,
-    token_SMALLER_EQUAL,
-    token_EQUAL,
-    token_NOT,
-    token_AND,
-    token_OR,
+	// Logic
+	token_GREATER,
+	token_GREATER_EQUAL,
+	token_SMALLER,
+	token_SMALLER_EQUAL,
+	token_EQUAL,
+	token_NOT,
+	token_AND,
+	token_OR,
 
-    // Punctuation
-    token_COMMA,
-    token_LEFT_PARENTH,
-    token_RIGHT_PARENTH,
-    token_LEFT_SQUARE,
-    token_RIGHT_SQUARE,
+	// Punctuation
+	token_COMMA,
+	token_LEFT_PARENTH,
+	token_RIGHT_PARENTH,
+	token_LEFT_SQUARE,
+	token_RIGHT_SQUARE,
 
-    // Others
-    token_IDENTIFIER,
-    token_UNKNOWN,
+	// Others
+	token_IDENTIFIER,
+	token_UNKNOWN,
 
 };
 
@@ -69,117 +69,117 @@ int p{};
 char character{};
 
 bool checkIfPropperWord(const std::string& code, int start, const std::string& word) {
-    int i;
-    bool poate_fi = true;
+	int i;
+	bool poate_fi = true;
 
-    for(i = 0; (i < (int) word.length()) && poate_fi && (start + i < (int) code.length());++i)
-        if(word[i] != code[start + i])
-            poate_fi=false;
+	for(i = 0; (i < (int) word.length()) && poate_fi && (start + i < (int) code.length());++i)
+		if(word[i] != code[start + i])
+			poate_fi=false;
 
-    return poate_fi && code[start + i] == ' ';
+	return poate_fi && code[start + i] == ' ';
 }
 
 int getNextToken() {
-    character = sourceCode[p];
-    currentToken = "";
+	character = sourceCode[p];
+	currentToken = "";
 
-    /*
-        Ia urmatorul token si pune-l in currentToken;
-        Returneaza tipul de token;
+	/*
+		Ia urmatorul token si pune-l in currentToken;
+		Returneaza tipul de token;
 
-        Exemplu:
-        10 "Hello_World!"Adevarat
+		Exemplu:
+		10 "Hello_World!"Adevarat
 
-        Dupa primul apel getNextToken
-        10 "Hello_World!"Adevarat
-          ^
-        p = 2;
-        currentToken = "10";
-        returneaza token_FLOAT;
+		Dupa primul apel getNextToken
+		10 "Hello_World!"Adevarat
+		  ^
+		p = 2;
+		currentToken = "10";
+		returneaza token_FLOAT;
 
-        Dupa al doilea apel
-        10 "Hello_World!"Adevarat
-                         ^
-        p = 17;
-        currentToken = "\"Hello_World!"\"
-        returneaza token_STRING
+		Dupa al doilea apel
+		10 "Hello_World!"Adevarat
+						 ^
+		p = 17;
+		currentToken = "\"Hello_World!"\"
+		returneaza token_STRING
 
-        Dupa al treilea apel
-        10 "Hello_World!"Adevarat
-                                 ^
-        p = 25 (Nu, nu da segmentation fault, se adauga '$' la sfarsit pentru fiecare linie)
-        currentToken = "Adevarat"
-        returneaza token_BOOL
-    */
-
-
-    // Spatiu
-    // Modifica mai tarziu pentru a identifica identarea (pentru tab-uri si spatii)
-    if(character == ' ') {
-        p++;
-        return getNextToken();
-    }
-
-    // Literals
-    if(isdigit(character)) {
-        do {
-            currentToken += character;
-            character = sourceCode[++p];
-        }
-        while(isdigit(character) and p < sourceCode.length() - 1);
-        if(character == '.') {
-            do {
-                currentToken += character;
-                character = sourceCode[++p];
-            }
-            while(isdigit(character) and p < sourceCode.length() - 1);
-        }
-        return token_FLOAT;
-    }
-    if(character == '\"') {
-        do {
-            currentToken += character;
-            character = sourceCode[++p];
-        }
-        while((character != '\"' or sourceCode[p-1] == '\\') and p < sourceCode.length() - 1);
-        currentToken += character;
-        if(character == '\"' and sourceCode[p-1] != '\\') {
-            p++;
-            return token_STRING;
-        }
-        else if(p != sourceCode.length() - 1) {p++;}
-        return token_UNKNOWN;
-    }
-    if(character == 'A' or character == 'F') {
-        do {
-            currentToken += character;
-            character = sourceCode[++p];
-        }
-        while(isalpha(character) and p < sourceCode.length() - 1);
-        if(currentToken == "Adevarat" or currentToken == "Fals") {
-            return token_BOOL;
-        }
-        else {
-            return token_IDENTIFIER;
-        }
-    }
-
-    //Input, Output
-    if(checkIfPropperWord(sourceCode, p, "citeste")) {
-        currentToken = "citeste";
-        p += currentToken.length();
-        return token_INPUT;
-    }
-    if(checkIfPropperWord(sourceCode, p, "scrie")) {
-        currentToken = "scrie";
-        p += currentToken.length();
-        return token_OUTPUT;
-    }
+		Dupa al treilea apel
+		10 "Hello_World!"Adevarat
+								 ^
+		p = 25 (Nu, nu da segmentation fault, se adauga '$' la sfarsit pentru fiecare linie)
+		currentToken = "Adevarat"
+		returneaza token_BOOL
+	*/
 
 
-    // Daca a ajuns pana aici, inseamna ca nu s-a potrivit cu nimic,
-    // deci pune caracterul in currentToken, creste p-ul si returneaza UNKNOWN
-    currentToken += character;
-    p++;
-    return token_UNKNOWN;
+	// Spatiu
+	// Modifica mai tarziu pentru a identifica identarea (pentru tab-uri si spatii)
+	if(character == ' ') {
+		p++;
+		return getNextToken();
+	}
+
+	// Literals
+	if(isdigit(character)) {
+		do {
+			currentToken += character;
+			character = sourceCode[++p];
+		}
+		while(isdigit(character) and p < sourceCode.length() - 1);
+		if(character == '.') {
+			do {
+				currentToken += character;
+				character = sourceCode[++p];
+			}
+			while(isdigit(character) and p < sourceCode.length() - 1);
+		}
+		return token_FLOAT;
+	}
+	if(character == '\"') {
+		do {
+			currentToken += character;
+			character = sourceCode[++p];
+		}
+		while((character != '\"' or sourceCode[p-1] == '\\') and p < sourceCode.length() - 1);
+		currentToken += character;
+		if(character == '\"' and sourceCode[p-1] != '\\') {
+			p++;
+			return token_STRING;
+		}
+		else if(p != sourceCode.length() - 1) {p++;}
+		return token_UNKNOWN;
+	}
+	if(character == 'A' or character == 'F') {
+		do {
+			currentToken += character;
+			character = sourceCode[++p];
+		}
+		while(isalpha(character) and p < sourceCode.length() - 1);
+		if(currentToken == "Adevarat" or currentToken == "Fals") {
+			return token_BOOL;
+		}
+		else {
+			return token_IDENTIFIER;
+		}
+	}
+
+	//Input, Output
+	if(checkIfPropperWord(sourceCode, p, "citeste")) {
+		currentToken = "citeste";
+		p += currentToken.length();
+		return token_INPUT;
+	}
+	if(checkIfPropperWord(sourceCode, p, "scrie")) {
+		currentToken = "scrie";
+		p += currentToken.length();
+		return token_OUTPUT;
+	}
+
+
+	// Daca a ajuns pana aici, inseamna ca nu s-a potrivit cu nimic,
+	// deci pune caracterul in currentToken, creste p-ul si returneaza UNKNOWN
+	currentToken += character;
+	p++;
+	return token_UNKNOWN;
 }

--- a/lexer.h
+++ b/lexer.h
@@ -4,165 +4,182 @@ std::string sourceCode{};
 std::string currentToken{};
 
 enum tokens {
-	// Keywords
-	token_INPUT,
-	token_OUTPUT,
-	token_IF,
-	token_THEN,
-	token_ELSE_IF,
-	token_ELSE,
-	token_WHILE,
-	token_EXECUTE,
-	token_DO_WHILE,
-	token_FOR,
+    // Keywords
+    token_INPUT,
+    token_OUTPUT,
+    token_IF,
+    token_THEN,
+    token_ELSE_IF,
+    token_ELSE,
+    token_WHILE,
+    token_EXECUTE,
+    token_DO_WHILE,
+    token_FOR,
 
-	// Literals [FACUT]
-	token_FLOAT,
-	token_STRING,
-	token_BOOL,
+    // Literals [FACUT]
+    token_FLOAT,
+    token_STRING,
+    token_BOOL,
 
-	// Data types when reading
-	// spre exemplu citeste x (numar natural, nenul)
-	// citeste x,y,z (numere reale)
-	token_ASSIGN_NATURAL,
-	token_ASSIGN_nonzeroNATURAL,
-	token_ASSIGN_INT,
-	token_ASSIGN_nonzeroINT, 
-	token_ASSIGN_FLOAT,
-	token_ASSIGN_nonzeroFLOAT,
-	token_ASSIGN_STRING,
-	token_ASSIGN_BOOL,
+    // Data types when reading
+    // spre exemplu citeste x (numar natural, nenul)
+    // citeste x,y,z (numere reale)
+    token_ASSIGN_NATURAL,
+    token_ASSIGN_nonzeroNATURAL,
+    token_ASSIGN_INT,
+    token_ASSIGN_nonzeroINT,
+    token_ASSIGN_FLOAT,
+    token_ASSIGN_nonzeroFLOAT,
+    token_ASSIGN_STRING,
+    token_ASSIGN_BOOL,
 
-	// Operands
-	token_ASSIGN,
-	token_PLUS,
-	token_MINUS,
-	token_ASTERISK,
-	token_DIVISION,
-	token_MODULO,
-	token_POWER,
+    // Operands
+    token_ASSIGN,
+    token_PLUS,
+    token_MINUS,
+    token_ASTERISK,
+    token_DIVISION,
+    token_MODULO,
+    token_POWER,
 
-	// Logic
-	token_GREATER,
-	token_GREATER_EQUAL,
-	token_SMALLER,
-	token_SMALLER_EQUAL,
-	token_EQUAL,
-	token_NOT,
-	token_AND,
-	token_OR,
+    // Logic
+    token_GREATER,
+    token_GREATER_EQUAL,
+    token_SMALLER,
+    token_SMALLER_EQUAL,
+    token_EQUAL,
+    token_NOT,
+    token_AND,
+    token_OR,
 
-	// Punctuation
-	token_COMMA,
-	token_LEFT_PARENTH,
-	token_RIGHT_PARENTH,
-	token_LEFT_SQUARE,
-	token_RIGHT_SQUARE,
+    // Punctuation
+    token_COMMA,
+    token_LEFT_PARENTH,
+    token_RIGHT_PARENTH,
+    token_LEFT_SQUARE,
+    token_RIGHT_SQUARE,
 
-	// Others
-	token_IDENTIFIER,
-	token_UNKNOWN,
+    // Others
+    token_IDENTIFIER,
+    token_UNKNOWN,
 
 };
 
 int p{};
 char character{};
 
+bool checkIfPropperWord(const std::string& code, int start, const std::string& word) {
+    int i;
+    bool poate_fi = true;
 
+    for(i = 0; (i < (int) word.length()) && poate_fi && (start + i < (int) code.length());++i)
+        if(word[i] != code[start + i])
+            poate_fi=false;
+
+    return poate_fi && code[start + i] == ' ';
+}
 
 int getNextToken() {
-	character = sourceCode[p];
-	currentToken = "";
+    character = sourceCode[p];
+    currentToken = "";
 
-	/*
-		Ia urmatorul token si pune-l in currentToken;
-		Returneaza tipul de token;
+    /*
+        Ia urmatorul token si pune-l in currentToken;
+        Returneaza tipul de token;
 
-		Exemplu:
-		10 "FuckYou"Adevarat
+        Exemplu:
+        10 "Hello_World!"Adevarat
 
-		Dupa primul apel getNextToken
-		69 "FuckYou"Adevarat
-		  ^
-		p = 2;
-		currentToken = 10;
-		returneaza token_FLOAT;
+        Dupa primul apel getNextToken
+        10 "Hello_World!"Adevarat
+          ^
+        p = 2;
+        currentToken = "10";
+        returneaza token_FLOAT;
 
-		Dupa al doilea apel
-		69 "FuckYou"Adevarat
-                    ^
-		p = 12;
-		currentToken = "FuckYou";
-		returneaza token_STRING
+        Dupa al doilea apel
+        10 "Hello_World!"Adevarat
+                         ^
+        p = 17;
+        currentToken = "\"Hello_World!"\"
+        returneaza token_STRING
 
-		Dupa al treilea apel
-		69 "FuckYou"Adevarat
-		                    ^
-		p = 20 (Nu, nu da segmentation fault, se adauga '$' la sfarsit pentru fiecare linie)
-		currentToken = Adevarat
-		returneaza token_BOOL
-	*/
-
-
-	// Spatiu
-	// Modifica mai tarziu pentru a identifica identarea (pentru tab-uri si spatii)
-	if(character == ' ') {
-		p++;
-		return getNextToken();
-	}
-
-	// Literals	
-	if(isdigit(character)) {
-		do {
-			currentToken += character;
-			character = sourceCode[++p];
-		}
-		while(isdigit(character) and p < sourceCode.length() - 1);
-		if(character == '.') {
-			do {
-				currentToken += character;
-				character = sourceCode[++p];
-			}
-			while(isdigit(character) and p < sourceCode.length() - 1);
-		} 
-		return token_FLOAT;
-	}
-	if(character == '\"') {
-		do {
-			currentToken += character;
-			character = sourceCode[++p];
-		}
-		while((character != '\"' or sourceCode[p-1] == '\\') and p < sourceCode.length() - 1);
-		currentToken += character;
-		if(character == '\"' and sourceCode[p-1] != '\\') {
-			p++;
-			return token_STRING;
-		}
-		else if(p != sourceCode.length() - 1) {p++;}
-		return token_UNKNOWN;
-	}
-	if(character == 'A' or character == 'F') {
-		do {
-			currentToken += character;
-			character = sourceCode[++p];
-		}
-		while(isalpha(character) and p < sourceCode.length() - 1);
-		if(currentToken == "Adevarat" or currentToken == "Fals") {
-			return token_BOOL;
-		}
-		else {
-			return token_IDENTIFIER;
-		}
-	}
+        Dupa al treilea apel
+        10 "Hello_World!"Adevarat
+                                 ^
+        p = 25 (Nu, nu da segmentation fault, se adauga '$' la sfarsit pentru fiecare linie)
+        currentToken = "Adevarat"
+        returneaza token_BOOL
+    */
 
 
-	
+    // Spatiu
+    // Modifica mai tarziu pentru a identifica identarea (pentru tab-uri si spatii)
+    if(character == ' ') {
+        p++;
+        return getNextToken();
+    }
+
+    // Literals
+    if(isdigit(character)) {
+        do {
+            currentToken += character;
+            character = sourceCode[++p];
+        }
+        while(isdigit(character) and p < sourceCode.length() - 1);
+        if(character == '.') {
+            do {
+                currentToken += character;
+                character = sourceCode[++p];
+            }
+            while(isdigit(character) and p < sourceCode.length() - 1);
+        }
+        return token_FLOAT;
+    }
+    if(character == '\"') {
+        do {
+            currentToken += character;
+            character = sourceCode[++p];
+        }
+        while((character != '\"' or sourceCode[p-1] == '\\') and p < sourceCode.length() - 1);
+        currentToken += character;
+        if(character == '\"' and sourceCode[p-1] != '\\') {
+            p++;
+            return token_STRING;
+        }
+        else if(p != sourceCode.length() - 1) {p++;}
+        return token_UNKNOWN;
+    }
+    if(character == 'A' or character == 'F') {
+        do {
+            currentToken += character;
+            character = sourceCode[++p];
+        }
+        while(isalpha(character) and p < sourceCode.length() - 1);
+        if(currentToken == "Adevarat" or currentToken == "Fals") {
+            return token_BOOL;
+        }
+        else {
+            return token_IDENTIFIER;
+        }
+    }
+
+    //Input, Output
+    if(checkIfPropperWord(sourceCode, p, "citeste")) {
+        currentToken = "citeste";
+        p += currentToken.length();
+        return token_INPUT;
+    }
+    if(checkIfPropperWord(sourceCode, p, "scrie")) {
+        currentToken = "scrie";
+        p += currentToken.length();
+        return token_OUTPUT;
+    }
 
 
-	
-	// Daca a ajuns pana aici, inseamna ca nu s-a potrivit cu nimic,
-	// deci pune caracterul in currentToken, creste p-ul si returneaza UNKNOWN
-	currentToken += character;
-	p++;
-	return token_UNKNOWN;
+    // Daca a ajuns pana aici, inseamna ca nu s-a potrivit cu nimic,
+    // deci pune caracterul in currentToken, creste p-ul si returneaza UNKNOWN
+    currentToken += character;
+    p++;
+    return token_UNKNOWN;
 }


### PR DESCRIPTION
Also made the example be less "obscene".

**Note**: A propper word is a word followed by a space character. This might need to be refined as a propper word might be the last word on a line so the next character will be the newline. For now it is good enough.